### PR TITLE
fix: ignore gcloud-auth-key

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,12 +32,12 @@ jobs:
           helm plugin install https://github.com/hayorov/helm-gcs
       - name: Dump GCloud auth key
         run: |
-          cat <<'EOF' > gcloud_auth_key.json
+          cat <<'EOF' > .secrets/gcloud_auth_key.json
           ${{ secrets.GCLOUD_AUTH_KEY }}
           EOF
       - name: Release chart
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/gcloud_auth_key.json
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/.secrets/gcloud_auth_key.json
         run: |
           helm repo add hahow gs://hahow-helm-charts
           helm repo update

--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Secrets
+.secrets/


### PR DESCRIPTION
法哥發現的洞，目前已做

- 先關閉 [`hahow-helm-charts` bucket](https://console.cloud.google.com/storage/browser/hahow-helm-charts/?project=cool-wharf-784) 的權限
- service account [`core-helm-charts-uploader`](https://console.cloud.google.com/iam-admin/serviceaccounts/details/109448002292619746671?project=cool-wharf-784) 僅有 `Storage Object Creator` 只能建立 object，危害較小，但還是暫時刪除 auth key

未來要請 jason 做

- approve this PR
- 重新產生 key，然後更新 GitHub secrets
- 重新開啟 `hahow-helm-charts` 對外公告

<img width="300" alt="image" src="https://user-images.githubusercontent.com/14314532/79674373-24b53180-8215-11ea-8db7-73ad6f04de7f.png">
