### PR TITLE
Revert "fix: wrong common.fullname"

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,4 +14,4 @@ type: library
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.2
+version: 0.4.1

--- a/templates/_name.tpl
+++ b/templates/_name.tpl
@@ -18,9 +18,9 @@ If release name contains chart name it will be used as a full name.
 {{- else }}
   {{- $name := default .Chart.Name .Values.nameOverride }}
   {{- if contains $name .Release.Name }}
-    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-  {{- else }}
     {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
耍白痴了

那個判斷式 [contain](https://helm.sh/docs/chart_template_guide/function_list/#contains) 是字串比對
如果 .Chart.Name 含有 .Release.Name 的內容的話 就不要講兩個字串相接了

這樣才是預期的結果！