### PR TITLE
feat: update new ingress api

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,4 +14,4 @@ type: library
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.2
+version: 1.0.0

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ ingress:
   hosts:
   - host: chart-example.local
     paths:
-    - /path/to/somewhere
+    - path: /path/to/somewhere
+      pathType: ImplementationSpecific
   tls:
   - secretName: chart-example-tls
     hosts:
@@ -380,9 +381,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: release-name-mychart
-          servicePort: 80
+          service:
+            name: release-name-mychart
+            port: 
+              number: 80
         path: /path/to/somewhere
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - "chart-example.local"

--- a/templates/_cronjob.yaml
+++ b/templates/_cronjob.yaml
@@ -10,9 +10,9 @@ spec:
 {{- $cronJob := index . 1 }}
 {{- $pod := index . 2 }}
 {{- $serviceAccount := index . 3 }}
-{{- if semverCompare ">=1.21.0" $top.Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">=1.21-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
-{{- else }}
+{{- else -}}
 apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob

--- a/templates/_hpa.yaml
+++ b/templates/_hpa.yaml
@@ -3,9 +3,9 @@
 {{- define "common.hpa.tpl" -}}
 {{- $top := first . }}
 {{- $autoscaling := index . 1 }}
-{{- if semverCompare ">=1.23.0" $top.Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">=1.23-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
-{{- else }}
+{{- else -}}
 apiVersion: autoscaling/v2beta2
 {{- end }}
 kind: HorizontalPodAutoscaler

--- a/templates/_ingress.yaml
+++ b/templates/_ingress.yaml
@@ -14,11 +14,11 @@ annotations:
 {{- $service := index . 2 }}
 {{- $fullName := include "common.fullname" $top }}
 {{- $svcPort := $service.port }}
-{{- if semverCompare ">=1.19.0" $top.Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">=1.19-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14.0" $top.Capabilities.KubeVersion.Version }}
+{{- else if semverCompare ">=1.14-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- else }}
+{{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
@@ -41,10 +41,20 @@ spec:
     http:
       paths:
       {{- range .paths }}
-      - path: {{ . }}
+      - path: {{ .path }}
+        {{- if and .pathType (semverCompare ">=1.18-0" $top.Capabilities.KubeVersion.GitVersion) }}
+        pathType: {{ .pathType }}
+        {{- end }}
         backend:
+          {{- if semverCompare ">=1.19-0" $top.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $svcPort }}
+          {{- else }}
           serviceName: {{ $fullName }}
           servicePort: {{ $svcPort }}
+          {{- end }}
       {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/_pdb.yaml
+++ b/templates/_pdb.yaml
@@ -3,9 +3,9 @@
 {{- define "common.pdb.tpl" -}}
 {{- $top := first . }}
 {{- $pdb := index . 1 }}
-{{- if semverCompare ">=1.21.0" $top.Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">=1.21-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1
-{{- else }}
+{{- else -}}
 apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget


### PR DESCRIPTION
# Summary

New Ingress API need specify pathType, so make ingress.value to object with contain `path` and `pathType` properties.
It's a Breaking Change, so bump major version to 1.0.0