### PR TITLE
update(api): update api version to 1.25 / 1.26

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,4 +14,4 @@ type: library
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.0
+version: 1.4.1

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Example use:
 Output:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
@@ -422,7 +422,7 @@ Example use:
 Output:
 
 ```yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/templates/_cronjob.yaml
+++ b/templates/_cronjob.yaml
@@ -13,7 +13,7 @@ spec:
 {{- if semverCompare ">=1.21-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
 {{- else -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 {{- end }}
 kind: CronJob
 metadata:

--- a/templates/_hpa.yaml
+++ b/templates/_hpa.yaml
@@ -6,7 +6,7 @@
 {{- if semverCompare ">=1.23-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 {{- end }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/templates/_pdb.yaml
+++ b/templates/_pdb.yaml
@@ -6,7 +6,7 @@
 {{- if semverCompare ">=1.21-0" $top.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1
 {{- else -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
## [2c-terraform](https://github.com/hahow/2c-terraform) 的共用 helm 包升級
> 今年 10/31 之前要做完

根據 [GCP 的指引](https://console.cloud.google.com/kubernetes/list/overview?project=acquisition-344311)，我們 GKE 上的 K8s 版本為 1.24，需要更新的 API 如下

1.25 後棄用
- batch/v1beta1/cronjobs
- policy/v1beta1/poddisruptionbudgets
- policy/v1beta1/podsecuritypolicies
- [ ] 記得這邊升級完 [2c-terraform](https://github.com/hahow/2c-terraform) 的 [datadog chart version 也要升級](https://github.com/hahow/2c-terraform/blob/7d7b7321a3f4227f3cda9bf6ad9623e37100b84b/modules/datadog/main.tf#L32)

1.26 後棄用
- autoscaling/v2beta2/horizontalpodautoscalers

---

本次更新的 API

- [batch/v1beta1 -> batch/v1](https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-25?_ga=2.172782499.-167285732.1686650945&hl=zh-cn#cronjob-v125)
- [policy/v1beta1 - > policy/v1](https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-25?_ga=2.172782499.-167285732.1686650945&hl=zh-cn#podsecuritypolicy)
- [autoscaling/v2beta2 -> autoscaling/v2](https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-26?_ga=2.127416205.-167285732.1686650945&hl=zh-cn#horizontalpodautoscaler-126)

上述 API 皆已包含在 1.24 之中，所以可以安心升級

---

合併之後根據 Github Action Work Flow 應該是會自動包版，故同時更新版號碼 -> `1.4.1`[（當前正式環境使用 1.3.1）](https://github.com/hahow/2c-terraform/blob/7d7b7321a3f4227f3cda9bf6ad9623e37100b84b/modules/hh-backend/helm-charts/hh-backend/Chart.yaml#L26)

屆時在用 dev 環境試試看效果。

- [ ] dev-0
- [ ] dev-1
- [ ] dev-2
- [ ] qa
- [ ] production